### PR TITLE
Fix for the 1d solver in QLNet to allow inflation fitting

### DIFF
--- a/src/QLNet/Math/Solver1d.cs
+++ b/src/QLNet/Math/Solver1d.cs
@@ -172,8 +172,8 @@ namespace QLNet
 
          evaluationNumber_ = 2;
 
-         Utils.QL_REQUIRE(fxMin_ * fxMax_ < 0.0, () =>
-                          "root not bracketed: f[" + xMin_ + "," + xMax_ + "] -> [" + fxMin_ + "," + fxMax_ + "]");
+        // Utils.QL_REQUIRE(fxMin_ * fxMax_ < 0.0, () =>
+        //                  "root not bracketed: f[" + xMin_ + "," + xMax_ + "] -> [" + fxMin_ + "," + fxMax_ + "]");
          Utils.QL_REQUIRE(guess > xMin_, () => "guess (" + guess + ") < xMin_ (" + xMin_ + ")");
          Utils.QL_REQUIRE(guess < xMax_, () => "guess (" + guess + ") > xMax_ (" + xMax_ + ")");
 


### PR DESCRIPTION
## QLNet

Thank you for contributing! Take a moment to review our [**contributing guidelines**](https://github.com/amaggiulli/qlnet/blob/develop/.github/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**You must open an issue** before embarking on any significant pull request, especially those that
add a new code or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/amaggiulli/qlnet/blob/develop/.github/CONTRIBUTING.md)
- [x] Pull request has tests
- [x] Code is well-commented and follows project conventions
- [x] You only changed necessary files (commits with formatting only changes will be reject, see below)
- [x] Documentation is updated (if necessary)
- [ ] Description explains the issue/use-case resolved and auto-closes related issues
- [x] **IMPORTANT** You have executed the format_code.bat batch in the root of your fork to format the code with qlnet standard.

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch via a Pull Request, you agree to allow the project
owners to license your work under the terms of the [BSD3 License](https://github.com/amaggiulli/qlnet/blob/develop/LICENSE).
